### PR TITLE
README.md is lye. short flags -nX can not use. fix this

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,26 @@ $ setddblock -xN ddb://ddb_lock_table/lock_item_id your_command
 ```
 
 ```console
-Usage: setddblock [ -nNxX ] [-endpoint <endpoint>] [-debug -version] ddb://<table_name>/<item_id> your_command
-  -N    (Default.) Delay. If fn is locked by another process, setlock waits until it can obtain a new lock.
-  -X    (Default.) If fn cannot be update-item (or put-item) or locked, setlock prints an error message and exits nonzero.
-  -debug
+Usage: setddblock [ -nNxX ] [--endpoint <endpoint>] [--debug --version] ddb://<table_name>/<item_id> your_command
+Flags:
+  -n
+        No delay. If fn is locked by another process, setlock gives up.
+  -N
+        (Default.) Delay. If fn is locked by another process, setlock waits until it can obtain a new lock.
+  -x
+        If fn cannot be update-item (or put-item) or locked, setlock exits zero.
+  -X
+        (Default.) If fn cannot be update-item (or put-item) or locked, setlock prints an error message and exits nonzero.
+  --debug
         show debug log
-  -endpoint string
+  --endpoint string
         If you switch remote, set AWS DynamoDB endpoint url.
-  -n    No delay. If fn is locked by another process, setlock gives up.
-  -region string
+  --region string
         aws region
-  -timeout string
+  --timeout string
         set command timeout
-  -version
+  --version
         show version
-  -x    If fn cannot be update-item (or put-item) or locked, setlock exits zero.
 ```
 
 the required IAM Policy is as follows:

--- a/cmd/setddblock/main.go
+++ b/cmd/setddblock/main.go
@@ -67,7 +67,10 @@ func _main() int {
 		}
 		args = append(args, arg)
 	}
-	flag.CommandLine.Parse(args[1:])
+	if err := flag.CommandLine.Parse(args[1:]); err != nil {
+		fmt.Fprintf(flag.CommandLine.Output(), "setddblock: %v\n", err)
+		return 1
+	}
 	if versionFlag {
 		fmt.Fprintf(flag.CommandLine.Output(), "setddblock version: %s\n", Version)
 		fmt.Fprintf(flag.CommandLine.Output(), "go runtime version: %s\n", runtime.Version())

--- a/cmd/setddblock/main.go
+++ b/cmd/setddblock/main.go
@@ -74,7 +74,7 @@ func _main() int {
 	offset := 0
 	if flag.NArg() < 1 {
 		flag.CommandLine.Usage()
-		fmt.Fprintf(os.Stderr, "\nsetddblock: missing ddb dsn\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\nsetddblock: missing ddb dsn\n")
 		return 1
 	}
 	if flag.Arg(1) == "--" {
@@ -82,7 +82,7 @@ func _main() int {
 	}
 	if flag.NArg()-offset < 2 {
 		flag.CommandLine.Usage()
-		fmt.Fprintf(os.Stderr, "\nsetddblock: missing your command\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "\nsetddblock: missing your command\n")
 		return 1
 	}
 	args = flag.Args()


### PR DESCRIPTION
before:
```
$ go run cmd/setddblock/main.go -nx ddb://setddblock/test -- sleep 100
flag provided but not defined: -nx
Usage: setddblock [ -nNxX ] [-endpoint <endpoint>] [-debug -version] ddb://<table_name>/<item_id> your_command
  -N    (Default.) Delay. If fn is locked by another process, setlock waits until it can obtain a new lock.
  -X    (Default.) If fn cannot be update-item (or put-item) or locked, setlock prints an error message and exits nonzero.
  -debug
        show debug log
  -endpoint string
        If you switch remote, set AWS DynamoDB endpoint url.
  -n    No delay. If fn is locked by another process, setlock gives up.
  -region string
        aws region
  -timeout string
        set command timeout
  -version
        show version
  -x    If fn cannot be update-item (or put-item) or locked, setlock exits zero.
exit status 2
```

after can use: -nx 

```
Usage: setddblock [ -nNxX ] [--endpoint <endpoint>] [--debug --version] ddb://<table_name>/<item_id> your_command
Flags:
  -n
        No delay. If fn is locked by another process, setlock gives up.
  -N
        (Default.) Delay. If fn is locked by another process, setlock waits until it can obtain a new lock.
  -x
        If fn cannot be update-item (or put-item) or locked, setlock exits zero.
  -X
        (Default.) If fn cannot be update-item (or put-item) or locked, setlock prints an error message and exits nonzero.
  --debug
        show debug log
  --endpoint string
        If you switch remote, set AWS DynamoDB endpoint url.
  --region string
        aws region
  --timeout string
        set command timeout
  --version
        show version
```
